### PR TITLE
Add property tests for signature validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@stacks/stacking": "^6.15.0",
         "@stacks/transactions": "^6.15.0",
         "bitcoin-address-validation": "^2.2.3",
+        "bitcoinjs-lib": "^6.1.5",
+        "bs58check": "^3.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2"
@@ -3669,6 +3671,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bip174": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.1.1.tgz",
+      "integrity": "sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/bitcoin-address-validation": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-2.2.3.tgz",
@@ -3677,6 +3687,33 @@
         "base58-js": "^1.0.0",
         "bech32": "^2.0.0",
         "sha256-uint8array": "^0.10.3"
+      }
+    },
+    "node_modules/bitcoinjs-lib": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
+      "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bech32": "^2.0.0",
+        "bip174": "^2.1.1",
+        "bs58check": "^3.0.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/body-parser": {
@@ -3762,6 +3799,26 @@
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-3.0.1.tgz",
+      "integrity": "sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/bser": {
@@ -7600,6 +7657,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
       "version": "5.4.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@stacks/stacking": "^6.15.0",
     "@stacks/transactions": "^6.15.0",
     "bitcoin-address-validation": "^2.2.3",
+    "bitcoinjs-lib": "^6.1.5",
+    "bs58check": "^3.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2"

--- a/src/tests/sig.test.ts
+++ b/src/tests/sig.test.ts
@@ -1,7 +1,26 @@
 import fc from 'fast-check';
-import { createSignature, createStackingClient } from '../utils/signature';
-import { getPoxRewardCycle, randomAuthId } from '../utils/helpers';
-import { Pox4SignatureTopic, StackingClient } from '@stacks/stacking';
+import {
+  createStackingClient,
+} from '../utils/signature';
+import {
+  SigFormErrorMessages,
+  getPoxRewardCycle,
+  randomAuthId,
+  validateParams,
+} from '../utils/helpers';
+import {
+  Pox4SignatureTopic,
+  StackingClient,
+  poxAddressToTuple,
+} from '@stacks/stacking';
+import {
+  btcAddressToPoxAddress,
+  buildSignerKeyMessageHash,
+  createSignatureTest,
+  signMessageHash,
+} from './testHelpers';
+import { Cl, callReadOnlyFunction } from '@stacks/transactions';
+import { StacksMainnet, StacksTestnet } from '@stacks/network';
 
 export const topicOptions = [
   'stack-stx',
@@ -11,41 +30,89 @@ export const topicOptions = [
   'agg-increase',
 ];
 
-let stackingClient: StackingClient | undefined; // Define stackingClient globally
-const prvKey =
+const TopicList: string[] = [
+  'stack-stx',
+  'stack-extend',
+  'stack-increase',
+  'stack-aggregation-commit',
+  'stack-aggregation-increase',
+];
+
+fc.configureGlobal({ numRuns: 5, endOnFailure: true });
+let stackingClientMainnet: StackingClient | undefined;
+let stackingClientTestnet: StackingClient | undefined;
+let prvKey =
   'b41c2a9e65247e73a690dbef18622c04cfa1df276bb65ee77ed73cc876e3e77b01';
+let pubKey =
+  '02778d476704afa540ac01438f62c371dc38741b00f35fb895e5cd48d070ebab41';
 
-// List of valid btcAddresses
-const btcAddresses: string[] = ['mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH'];
+const btcAddresses: string[] = [
+  'mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH',
+  'mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC',
+  'muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG',
+  'mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7',
+  'mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8',
+  'mweN5WVqadScHdA81aATSdcVr4B6dNokqx',
+];
 
-beforeAll(() => {
-  stackingClient = createStackingClient(
-    'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
-    'mainnet'
-  );
-});
+const btcAddressesMalformed: string[] = [
+  'mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsHf',
+  'mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNCs',
+  'muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErGh',
+  'mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX74',
+  'mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8d',
+  'mweN5WVqadScHdA81aATSdcVr4B6dNokqxs',
+];
+
+const MAINNET_CHAIN_ID = 1;
+const TESTNET_CHAIN_ID = 2147483648;
 
 describe('Signature generation', () => {
+  let curCycleMainnet = 0;
+  let curCycleTestnet = 0;
+  beforeAll(async () => {
+    stackingClientMainnet = createStackingClient(
+      'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+      'mainnet'
+    )!;
+    curCycleMainnet = await getPoxRewardCycle(stackingClientMainnet);
+    stackingClientTestnet = createStackingClient(
+      'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+      'testnet'
+    )!;
+    curCycleTestnet = await getPoxRewardCycle(stackingClientTestnet);
+  });
+
   it('should generate a valid signature for mainnet', () => {
     fc.assert(
       fc.asyncProperty(
         fc.constantFrom(...topicOptions),
-        fc.constantFrom(...btcAddresses), // replace with actual btc addresses
-        fc.integer(), // replace with correct reward cycle (using chain)
-        fc.integer(),
-        fc.integer(),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
-          expect(stackingClient).toBeDefined();
+          expect(stackingClientMainnet).toBeDefined();
           const authId = randomAuthId();
-          const curCycle = await getPoxRewardCycle(
-            stackingClient as StackingClient
+          const { version, hashBytes } = btcAddressToPoxAddress(poxAddress);
+          const sig = buildSignerKeyMessageHash(
+            version,
+            hashBytes,
+            rewardCycle,
+            topic,
+            period,
+            maxAmount,
+            authId,
+            MAINNET_CHAIN_ID
           );
-          expect(curCycle).toBeGreaterThanOrEqual(85);
+          const expected = signMessageHash(prvKey, sig).toString('hex');
 
           // Act
-          const signature = createSignature(
-            stackingClient as StackingClient,
+          const actual = createSignatureTest(
+            stackingClientMainnet as StackingClient,
             topic as Pox4SignatureTopic,
             poxAddress,
             rewardCycle,
@@ -55,10 +122,1944 @@ describe('Signature generation', () => {
             authId
           );
 
-          // console.log(signature);
+          // Assert
+          expect(actual).toEqual(expected);
+        }
+      )
+    );
+  });
+
+  it('should generate a valid signature for testnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(...topicOptions),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+          const { version, hashBytes } = btcAddressToPoxAddress(poxAddress);
+          const sig = buildSignerKeyMessageHash(
+            version,
+            hashBytes,
+            rewardCycle,
+            topic,
+            period,
+            maxAmount,
+            authId,
+            TESTNET_CHAIN_ID
+          );
+          const expected = signMessageHash(prvKey, sig).toString('hex');
+
+          // Act
+          const actual = createSignatureTest(
+            stackingClientTestnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
 
           // Assert
-          expect(true).toBe(true);
+          expect(actual).toEqual(expected);
+        }
+      )
+    );
+  });
+
+  // stack-stx, stack-extend, stack-increase
+  it('create stack-stx, stack-extend, stack-increase signature for mainnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0], topicOptions[1], topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+          const signature = createSignatureTest(
+            stackingClientMainnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
+
+          // Act
+          const options = {
+            contractAddress: 'SP000000000000000000002Q6VF78',
+            contractName: 'pox-4',
+            functionName: 'verify-signer-key-sig',
+            functionArgs: [
+              poxAddressToTuple(poxAddress),
+              Cl.uint(curCycleMainnet),
+              Cl.stringAscii(topic),
+              Cl.uint(period),
+              Cl.some(Cl.bufferFromHex(signature)),
+              Cl.bufferFromHex(pubKey),
+              Cl.uint(maxAmount),
+              Cl.uint(maxAmount),
+              Cl.uint(authId),
+            ],
+            network: new StacksMainnet(),
+            senderAddress: 'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+          };
+          const result = await callReadOnlyFunction(options);
+          // Assert
+          expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+        }
+      )
+    );
+  });
+
+  it('create stack-stx, stack-extend, stack-increase signature for testnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0], topicOptions[1], topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+          const signature = createSignatureTest(
+            stackingClientTestnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
+
+          // Act
+          const options = {
+            contractAddress: 'ST000000000000000000002AMW42H',
+            contractName: 'pox-4',
+            functionName: 'verify-signer-key-sig',
+            functionArgs: [
+              poxAddressToTuple(poxAddress),
+              Cl.uint(curCycleTestnet),
+              Cl.stringAscii(topic),
+              Cl.uint(period),
+              Cl.some(Cl.bufferFromHex(signature)),
+              Cl.bufferFromHex(pubKey),
+              Cl.uint(maxAmount),
+              Cl.uint(maxAmount),
+              Cl.uint(authId),
+            ],
+            network: new StacksTestnet(),
+            senderAddress: 'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+          };
+          const result = await callReadOnlyFunction(options);
+          // Assert
+          expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+        }
+      )
+    );
+  });
+
+  // agg-commit
+  it('create agg-commit signature for mainnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+          const signature = createSignatureTest(
+            stackingClientMainnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
+
+          // Act
+          const options = {
+            contractAddress: 'SP000000000000000000002Q6VF78',
+            contractName: 'pox-4',
+            functionName: 'verify-signer-key-sig',
+            functionArgs: [
+              poxAddressToTuple(poxAddress),
+              Cl.uint(curCycleMainnet),
+              Cl.stringAscii(topicOptions[3]),
+              Cl.uint(period),
+              Cl.some(Cl.bufferFromHex(signature)),
+              Cl.bufferFromHex(pubKey),
+              Cl.uint(maxAmount),
+              Cl.uint(maxAmount),
+              Cl.uint(authId),
+            ],
+            network: new StacksMainnet(),
+            senderAddress: 'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+          };
+          const result = await callReadOnlyFunction(options);
+          // Assert
+          expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+        }
+      )
+    );
+  });
+
+  it('create agg-commit signature for testnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+          const signature = createSignatureTest(
+            stackingClientTestnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
+
+          // Act
+          const options = {
+            contractAddress: 'ST000000000000000000002AMW42H',
+            contractName: 'pox-4',
+            functionName: 'verify-signer-key-sig',
+            functionArgs: [
+              poxAddressToTuple(poxAddress),
+              Cl.uint(curCycleTestnet),
+              Cl.stringAscii(topicOptions[3]),
+              Cl.uint(period),
+              Cl.some(Cl.bufferFromHex(signature)),
+              Cl.bufferFromHex(pubKey),
+              Cl.uint(maxAmount),
+              Cl.uint(maxAmount),
+              Cl.uint(authId),
+            ],
+            network: new StacksTestnet(),
+            senderAddress: 'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+          };
+          const result = await callReadOnlyFunction(options);
+          // Assert
+          expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+        }
+      )
+    );
+  });
+
+  // agg-increase
+  it('create agg-increase signature for mainnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+          const signature = createSignatureTest(
+            stackingClientMainnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
+
+          // Act
+          const options = {
+            contractAddress: 'SP000000000000000000002Q6VF78',
+            contractName: 'pox-4',
+            functionName: 'verify-signer-key-sig',
+            functionArgs: [
+              poxAddressToTuple(poxAddress),
+              Cl.uint(curCycleMainnet),
+              Cl.stringAscii(topicOptions[4]),
+              Cl.uint(period),
+              Cl.some(Cl.bufferFromHex(signature)),
+              Cl.bufferFromHex(pubKey),
+              Cl.uint(maxAmount),
+              Cl.uint(maxAmount),
+              Cl.uint(authId),
+            ],
+            network: new StacksMainnet(),
+            senderAddress: 'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+          };
+          const result = await callReadOnlyFunction(options);
+          // Assert
+          expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+        }
+      )
+    );
+  });
+
+  it('create agg-increase signature for testnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+          const signature = createSignatureTest(
+            stackingClientTestnet as StackingClient,
+            topic as Pox4SignatureTopic,
+            poxAddress,
+            rewardCycle,
+            period,
+            prvKey,
+            maxAmount,
+            authId
+          );
+
+          // Act
+          const options = {
+            contractAddress: 'ST000000000000000000002AMW42H',
+            contractName: 'pox-4',
+            functionName: 'verify-signer-key-sig',
+            functionArgs: [
+              poxAddressToTuple(poxAddress),
+              Cl.uint(curCycleTestnet),
+              Cl.stringAscii(topicOptions[4]),
+              Cl.uint(period),
+              Cl.some(Cl.bufferFromHex(signature)),
+              Cl.bufferFromHex(pubKey),
+              Cl.uint(maxAmount),
+              Cl.uint(maxAmount),
+              Cl.uint(authId),
+            ],
+            network: new StacksTestnet(),
+            senderAddress: 'STGV0HNRP9XMMQ3Y1PW1Q7QQERVT37R3RPADMHFP',
+          };
+          const result = await callReadOnlyFunction(options);
+
+          // Assert
+          expect(result).toStrictEqual(Cl.ok(Cl.bool(true)));
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for mainnet, larger period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 13 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PeriodExceedsMaximum,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for testnet, larger period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 13 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PeriodExceedsMaximum,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for mainnet, negative or zero period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ max: 0 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.NegativeOrZeroPeriod,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for testnet, negative or zero period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ max: 0 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.NegativeOrZeroPeriod,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for mainnet, past reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet - 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PastRewCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for testnet, past reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet - 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PastRewCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for mainnet, reward cycle greater than current', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet + 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.RewCycleGreaterThanCurrent(curCycleMainnet),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for testnet, reward cycle greater than current', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet + 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.RewCycleGreaterThanCurrent(curCycleTestnet),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for mainnet, undefined reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-stx sig for testnet, undefined reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[0]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[0],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for mainnet, larger period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 13 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PeriodExceedsMaximum,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for testnet, larger period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 13 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PeriodExceedsMaximum,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for mainnet, negative or zero period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ max: 0 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.NegativeOrZeroPeriod,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for testnet, negative or zero period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ max: 0 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.NegativeOrZeroPeriod,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for mainnet, past reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet - 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PastRewCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for testnet, past reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet - 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PastRewCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for mainnet, reward cycle greater than current', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet + 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.RewCycleGreaterThanCurrent(curCycleMainnet),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for testnet, reward cycle greater than current', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet + 1);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.RewCycleGreaterThanCurrent(curCycleTestnet),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for mainnet, undefined reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-extend sig for testnet, undefined reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[1]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[1],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for mainnet, larger period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 13 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PeriodExceedsMaximum,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for testnet, larger period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 13 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PeriodExceedsMaximum,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for mainnet, negative or zero period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ max: 0 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.NegativeOrZeroPeriod,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for testnet, negative or zero period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ max: 0 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.NegativeOrZeroPeriod,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for mainnet, past reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet - 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PastRewCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for testnet, past reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet - 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.PastRewCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for mainnet, reward cycle greater than current', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet + 1);
+        }),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.RewCycleGreaterThanCurrent(curCycleMainnet),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for testnet, reward cycle greater than current', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet + 1);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.RewCycleGreaterThanCurrent(curCycleTestnet),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for mainnet, undefined reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create stack-increase sig for testnet, undefined reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[2]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.integer({ min: 0, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+          const authId = randomAuthId();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[2],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-commit sig for mainnet, wrong period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet + 1);
+        }),
+        fc.integer().filter((n) => n !== 1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[3],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[3]),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-commit sig for testnet, wrong period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet + 1);
+        }),
+        fc.integer().filter((n) => n !== 1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[3],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[3]),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-commit sig for mainnet, not future reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[3],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggFutureCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-commit sig for testnet, not future reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[3],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggFutureCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-commit sig for mainnet, undefiend reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[3],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-commit sig for testnet, undefiend reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[3]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[3],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-increase sig for mainnet, wrong period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet + 1);
+        }),
+        fc.integer().filter((n) => n !== 1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[4],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[4]),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-increase sig for testnet, wrong period', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet + 1);
+        }),
+        fc.integer().filter((n) => n !== 1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[4],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[4]),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-increase sig for mainnet, not future reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[4],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggFutureCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-increase sig for testnet, not future reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[4],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.AggFutureCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-increase sig for mainnet, undefiend reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[4],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create agg-increase sig for testnet, undefiend reward cycle', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(topicOptions[4]),
+        fc.constantFrom(...btcAddresses),
+        fc.constant(undefined),
+        fc.constant(1),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            TopicList[4],
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.EmptyRewardCycle,
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create non-existing topic sig, mainnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            topic,
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.InvalidTopic(topic),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create non-existing topic sig, testnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.string(),
+        fc.constantFrom(...btcAddresses),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            topic,
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.InvalidTopic(topic),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create invalid btcAddress sig, mainnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(...topicOptions),
+        fc.constantFrom(...btcAddressesMalformed),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleMainnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientMainnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            topic,
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientMainnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.InvalidPoxAddress(poxAddress),
+          ]);
+        }
+      )
+    );
+  });
+
+  it('create invalid btcAddress sig, testnet', () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom(...topicOptions),
+        fc.constantFrom(...btcAddressesMalformed),
+        fc.integer().chain((rewardCycle) => {
+          return fc.constant(curCycleTestnet);
+        }),
+        fc.integer({ min: 1, max: 12 }),
+        fc.integer({ min: 0 }),
+        async (topic, poxAddress, rewardCycle, period, maxAmount) => {
+          // Arrange
+          expect(stackingClientTestnet).toBeDefined();
+
+          // Act
+          const message = await validateParams(
+            poxAddress,
+            topic,
+            rewardCycle,
+            maxAmount,
+            period,
+            stackingClientTestnet!
+          );
+
+          // Assert
+          expect(message).toStrictEqual([
+            false,
+            SigFormErrorMessages.InvalidPoxAddress(poxAddress),
+          ]);
         }
       )
     );

--- a/src/tests/sig.test.ts
+++ b/src/tests/sig.test.ts
@@ -28,14 +28,6 @@ const topicOptions = [
   'agg-increase',
 ];
 
-const TopicList: string[] = [
-  'stack-stx',
-  'stack-extend',
-  'stack-increase',
-  'stack-aggregation-commit',
-  'stack-aggregation-increase',
-];
-
 fc.configureGlobal({ numRuns: 5, endOnFailure: true });
 let stackingClientMainnet: StackingClient | undefined;
 let stackingClientTestnet: StackingClient | undefined;
@@ -506,7 +498,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -540,7 +532,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -574,7 +566,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -608,7 +600,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -642,7 +634,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -676,7 +668,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -710,7 +702,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -744,7 +736,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -776,7 +768,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -808,7 +800,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[0],
+            topicOptions[0] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -842,7 +834,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -876,7 +868,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -910,7 +902,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -944,7 +936,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -978,7 +970,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1012,7 +1004,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1046,7 +1038,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1080,7 +1072,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1112,7 +1104,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1144,7 +1136,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[1],
+            topicOptions[1] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1178,7 +1170,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1212,7 +1204,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1246,7 +1238,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1280,7 +1272,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1314,7 +1306,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1348,7 +1340,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1382,7 +1374,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1416,7 +1408,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1448,7 +1440,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1480,7 +1472,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[2],
+            topicOptions[2] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1514,7 +1506,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[3],
+            topicOptions[3] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1524,7 +1516,7 @@ describe('Signature generation', () => {
           // Assert
           expect(message).toStrictEqual([
             false,
-            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[3]),
+            SigFormErrorMessages.AggCommitWrongPeriod(topicOptions[3]),
           ]);
         }
       )
@@ -1548,7 +1540,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[3],
+            topicOptions[3] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1558,7 +1550,7 @@ describe('Signature generation', () => {
           // Assert
           expect(message).toStrictEqual([
             false,
-            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[3]),
+            SigFormErrorMessages.AggCommitWrongPeriod(topicOptions[3]),
           ]);
         }
       )
@@ -1582,7 +1574,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[3],
+            topicOptions[3] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1616,7 +1608,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[3],
+            topicOptions[3] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1648,7 +1640,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[3],
+            topicOptions[3] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1680,7 +1672,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[3],
+            topicOptions[3] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1714,7 +1706,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[4],
+            topicOptions[4] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1724,7 +1716,7 @@ describe('Signature generation', () => {
           // Assert
           expect(message).toStrictEqual([
             false,
-            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[4]),
+            SigFormErrorMessages.AggCommitWrongPeriod(topicOptions[4]),
           ]);
         }
       )
@@ -1748,7 +1740,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[4],
+            topicOptions[4] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1758,7 +1750,7 @@ describe('Signature generation', () => {
           // Assert
           expect(message).toStrictEqual([
             false,
-            SigFormErrorMessages.AggCommitWrongPeriod(TopicList[4]),
+            SigFormErrorMessages.AggCommitWrongPeriod(topicOptions[4]),
           ]);
         }
       )
@@ -1782,7 +1774,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[4],
+            topicOptions[4] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1816,7 +1808,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[4],
+            topicOptions[4] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1848,7 +1840,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[4],
+            topicOptions[4] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1880,7 +1872,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            TopicList[4],
+            topicOptions[4] as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1914,7 +1906,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            topic,
+            topic as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1924,7 +1916,7 @@ describe('Signature generation', () => {
           // Assert
           expect(message).toStrictEqual([
             false,
-            SigFormErrorMessages.InvalidTopic(topic),
+            SigFormErrorMessages.WrongTopic,
           ]);
         }
       )
@@ -1948,7 +1940,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            topic,
+            topic as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -1958,7 +1950,7 @@ describe('Signature generation', () => {
           // Assert
           expect(message).toStrictEqual([
             false,
-            SigFormErrorMessages.InvalidTopic(topic),
+            SigFormErrorMessages.WrongTopic,
           ]);
         }
       )
@@ -1982,7 +1974,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            topic,
+            topic as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,
@@ -2016,7 +2008,7 @@ describe('Signature generation', () => {
           // Act
           const message = await validateParams(
             poxAddress,
-            topic,
+            topic as Pox4SignatureTopic,
             rewardCycle,
             maxAmount,
             period,

--- a/src/tests/sig.test.ts
+++ b/src/tests/sig.test.ts
@@ -1,7 +1,5 @@
 import fc from 'fast-check';
-import {
-  createStackingClient,
-} from '../utils/signature';
+import { createStackingClient } from '../utils/signature';
 import {
   SigFormErrorMessages,
   getPoxRewardCycle,
@@ -22,7 +20,7 @@ import {
 import { Cl, callReadOnlyFunction } from '@stacks/transactions';
 import { StacksMainnet, StacksTestnet } from '@stacks/network';
 
-export const topicOptions = [
+const topicOptions = [
   'stack-stx',
   'stack-extend',
   'stack-increase',
@@ -41,9 +39,9 @@ const TopicList: string[] = [
 fc.configureGlobal({ numRuns: 5, endOnFailure: true });
 let stackingClientMainnet: StackingClient | undefined;
 let stackingClientTestnet: StackingClient | undefined;
-let prvKey =
+const prvKey =
   'b41c2a9e65247e73a690dbef18622c04cfa1df276bb65ee77ed73cc876e3e77b01';
-let pubKey =
+const pubKey =
   '02778d476704afa540ac01438f62c371dc38741b00f35fb895e5cd48d070ebab41';
 
 const btcAddresses: string[] = [
@@ -88,7 +86,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(...topicOptions),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -134,7 +132,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(...topicOptions),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -181,7 +179,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0], topicOptions[1], topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -233,7 +231,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0], topicOptions[1], topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -286,7 +284,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[3]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.constant(1),
@@ -338,7 +336,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[3]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.constant(1),
@@ -391,7 +389,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[4]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.constant(1),
@@ -443,7 +441,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[4]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.constant(1),
@@ -496,7 +494,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 13 }),
@@ -504,7 +502,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -531,7 +528,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 13 }),
@@ -539,7 +536,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -566,7 +562,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ max: 0 }),
@@ -574,7 +570,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -601,7 +596,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ max: 0 }),
@@ -609,7 +604,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -636,7 +630,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet - 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -644,7 +638,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -671,7 +664,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet - 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -679,7 +672,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -706,7 +698,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet + 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -714,7 +706,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -741,7 +732,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[0]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet + 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -749,7 +740,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -782,7 +772,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -815,7 +804,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -842,7 +830,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 13 }),
@@ -850,7 +838,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -877,7 +864,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 13 }),
@@ -885,7 +872,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -912,7 +898,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ max: 0 }),
@@ -920,7 +906,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -947,7 +932,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ max: 0 }),
@@ -955,7 +940,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -982,7 +966,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet - 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -990,7 +974,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1017,7 +1000,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet - 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -1025,7 +1008,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1052,7 +1034,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet + 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -1060,7 +1042,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1087,7 +1068,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[1]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet + 1);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -1095,7 +1076,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1128,7 +1108,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1161,7 +1140,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1188,7 +1166,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 13 }),
@@ -1196,7 +1174,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1223,7 +1200,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 13 }),
@@ -1231,7 +1208,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1258,7 +1234,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ max: 0 }),
@@ -1266,7 +1242,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1293,7 +1268,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ max: 0 }),
@@ -1301,7 +1276,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1328,7 +1302,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet - 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -1336,7 +1310,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1363,7 +1336,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet - 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -1371,7 +1344,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1398,7 +1370,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet + 1);
         }),
         fc.integer({ min: 0, max: 12 }),
@@ -1406,7 +1378,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1433,7 +1404,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[2]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet + 1);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -1441,7 +1412,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1474,7 +1444,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientMainnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1507,7 +1476,6 @@ describe('Signature generation', () => {
         async (topic, poxAddress, rewardCycle, period, maxAmount) => {
           // Arrange
           expect(stackingClientTestnet).toBeDefined();
-          const authId = randomAuthId();
 
           // Act
           const message = await validateParams(
@@ -1534,7 +1502,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[3]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet + 1);
         }),
         fc.integer().filter((n) => n !== 1),
@@ -1568,7 +1536,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[3]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet + 1);
         }),
         fc.integer().filter((n) => n !== 1),
@@ -1602,7 +1570,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[3]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.constant(1),
@@ -1636,7 +1604,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[3]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.constant(1),
@@ -1734,7 +1702,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[4]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet + 1);
         }),
         fc.integer().filter((n) => n !== 1),
@@ -1768,7 +1736,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[4]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet + 1);
         }),
         fc.integer().filter((n) => n !== 1),
@@ -1802,7 +1770,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[4]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.constant(1),
@@ -1836,7 +1804,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(topicOptions[4]),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.constant(1),
@@ -1934,7 +1902,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.string(),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -1968,7 +1936,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.string(),
         fc.constantFrom(...btcAddresses),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -2002,7 +1970,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(...topicOptions),
         fc.constantFrom(...btcAddressesMalformed),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleMainnet);
         }),
         fc.integer({ min: 1, max: 12 }),
@@ -2036,7 +2004,7 @@ describe('Signature generation', () => {
       fc.asyncProperty(
         fc.constantFrom(...topicOptions),
         fc.constantFrom(...btcAddressesMalformed),
-        fc.integer().chain((rewardCycle) => {
+        fc.integer().chain(() => {
           return fc.constant(curCycleTestnet);
         }),
         fc.integer({ min: 1, max: 12 }),

--- a/src/tests/testHelpers.ts
+++ b/src/tests/testHelpers.ts
@@ -1,0 +1,152 @@
+import { Pox4SignatureTopic, StackingClient } from '@stacks/stacking';
+import {
+  AddressHashMode,
+  Cl,
+  ClarityValue,
+  createStacksPrivateKey,
+  serializeCV,
+  signWithKey,
+} from '@stacks/transactions';
+import bs58check from 'bs58check';
+import { createHash } from 'crypto';
+
+const sha256 = (data: Buffer): Buffer =>
+  createHash('sha256').update(data).digest();
+
+const structuredDataHash = (structuredData: ClarityValue): Buffer =>
+  sha256(Buffer.from(serializeCV(structuredData)));
+
+const generateDomainHash = (chainId: number): ClarityValue =>
+  Cl.tuple({
+    name: Cl.stringAscii('pox-4-signer'),
+    version: Cl.stringAscii('1.0.0'),
+    'chain-id': Cl.uint(chainId),
+  });
+
+const generateMessageHash = (
+  version: number,
+  hashbytes: number[],
+  reward_cycle: number,
+  topic: string,
+  period: number,
+  auth_id: number,
+  max_amount: number
+): ClarityValue =>
+  Cl.tuple({
+    'pox-addr': Cl.tuple({
+      version: Cl.buffer(Uint8Array.from([version])),
+      hashbytes: Cl.buffer(Uint8Array.from(hashbytes)),
+    }),
+    'reward-cycle': Cl.uint(reward_cycle),
+    topic: Cl.stringAscii(topic),
+    period: Cl.uint(period),
+    'auth-id': Cl.uint(auth_id),
+    'max-amount': Cl.uint(max_amount),
+  });
+
+const generateMessagePrefixBuffer = (prefix: string) =>
+  Buffer.from(prefix, 'hex');
+
+const SIP_018_MESSAGE_PREFIX = '534950303138';
+
+export const buildSignerKeyMessageHash = (
+  version: number,
+  hashbytes: number[],
+  reward_cycle: number,
+  topic: string,
+  period: number,
+  max_amount: number,
+  auth_id: number,
+  chainId: number
+) => {
+  const domain_hash = structuredDataHash(generateDomainHash(chainId));
+  const message_hash = structuredDataHash(
+    generateMessageHash(
+      version,
+      hashbytes,
+      reward_cycle,
+      topic,
+      period,
+      auth_id,
+      max_amount
+    )
+  );
+  const structuredDataPrefix = generateMessagePrefixBuffer(
+    SIP_018_MESSAGE_PREFIX
+  );
+
+  const signer_key_message_hash = sha256(
+    Buffer.concat([structuredDataPrefix, domain_hash, message_hash])
+  );
+
+  return signer_key_message_hash;
+};
+
+export const signMessageHash = (privateKey: string, messageHash: Buffer) => {
+  const data = signWithKey(
+    createStacksPrivateKey(privateKey),
+    messageHash.toString('hex')
+  ).data;
+  return Buffer.from(data.slice(2) + data.slice(0, 2), 'hex');
+};
+
+function decodeBitcoinAddress(btcAddress: string) {
+  const payload = bs58check.decode(btcAddress);
+
+  if (payload.length !== 21) {
+    throw new Error('Invalid address length');
+  }
+
+  const version = payload[0];
+  const hashBytes = payload.slice(1);
+
+  return { version, hashBytes };
+}
+
+// Function to convert a Bitcoin address to a PoX address
+export function btcAddressToPoxAddress(btcAddress: string) {
+  const { version, hashBytes } = decodeBitcoinAddress(btcAddress);
+
+  let poxVersion;
+
+  // Determine the PoX version based on the Bitcoin address version
+  switch (version) {
+    case 0x00: // P2PKH
+      poxVersion = AddressHashMode.SerializeP2PKH;
+      break;
+    case 0x05: // P2SH
+      poxVersion = AddressHashMode.SerializeP2SH;
+      break;
+    case 0x6f: // Testnet P2PKH
+      poxVersion = AddressHashMode.SerializeP2PKH;
+      break;
+    case 0xc4: // Testnet P2SH
+      poxVersion = AddressHashMode.SerializeP2SH;
+      break;
+    default:
+      throw new Error('Unsupported Bitcoin address version');
+  }
+
+  return { version: poxVersion, hashBytes: Array.from(hashBytes) };
+}
+
+export const createSignatureTest = (
+  stackingClient: StackingClient,
+  topic: Pox4SignatureTopic,
+  poxAddress: string,
+  rewardCycle: number,
+  period: number,
+  signerPrivateKey: string,
+  maxAmount: number,
+  authId: number
+) => {
+  return stackingClient.signPoxSignature({
+    topic,
+    poxAddress,
+    rewardCycle,
+    period,
+    signerPrivateKey: createStacksPrivateKey(signerPrivateKey),
+    maxAmount,
+    authId,
+  });
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { StackingClient } from '@stacks/stacking';
 import validate from 'bitcoin-address-validation';
 
-const TopicMapping: string[] = [
+const TopicList: string[] = [
   'stack-stx',
   'stack-extend',
   'stack-increase',
@@ -26,7 +26,7 @@ export const validateParams = async (
   if (!validate(poxAddress))
     return [false, SigFormErrorMessages.InvalidPoxAddress(poxAddress)];
 
-  if (!TopicMapping.includes(topic))
+  if (!TopicList.includes(topic))
     return [false, SigFormErrorMessages.InvalidTopic(topic)];
 
   if (maxAmount > Number.MAX_SAFE_INTEGER)
@@ -82,7 +82,7 @@ export const testRewardCycle = (
     string,
     (selectedRewardCycle: number) => [boolean, string]
   > = {
-    [TopicMapping[0]]: (selectedRewardCycle: number): [boolean, string] => {
+    [TopicList[0]]: (selectedRewardCycle: number): [boolean, string] => {
       if (!selectedRewardCycle)
         return [false, SigFormErrorMessages.EmptyRewardCycle];
       if (selectedRewardCycle < currentRewardCycle)
@@ -94,7 +94,7 @@ export const testRewardCycle = (
         ];
       return [true, 'OK'];
     },
-    [TopicMapping[1]]: (selectedRewardCycle: number): [boolean, string] => {
+    [TopicList[1]]: (selectedRewardCycle: number): [boolean, string] => {
       if (!selectedRewardCycle)
         return [false, SigFormErrorMessages.EmptyRewardCycle];
       if (selectedRewardCycle < currentRewardCycle)
@@ -106,7 +106,7 @@ export const testRewardCycle = (
         ];
       return [true, 'OK'];
     },
-    [TopicMapping[2]]: (selectedRewardCycle: number): [boolean, string] => {
+    [TopicList[2]]: (selectedRewardCycle: number): [boolean, string] => {
       if (!selectedRewardCycle)
         return [false, SigFormErrorMessages.EmptyRewardCycle];
       if (selectedRewardCycle < currentRewardCycle)
@@ -118,14 +118,14 @@ export const testRewardCycle = (
         ];
       return [true, 'OK'];
     },
-    [TopicMapping[3]]: (selectedRewardCycle: number): [boolean, string] => {
+    [TopicList[3]]: (selectedRewardCycle: number): [boolean, string] => {
       if (!selectedRewardCycle)
         return [false, SigFormErrorMessages.EmptyRewardCycle];
       if (selectedRewardCycle <= currentRewardCycle)
         return [false, SigFormErrorMessages.AggFutureCycle];
       return [true, 'OK'];
     },
-    [TopicMapping[4]]: (selectedRewardCycle: number): [boolean, string] => {
+    [TopicList[4]]: (selectedRewardCycle: number): [boolean, string] => {
       if (!selectedRewardCycle)
         return [false, SigFormErrorMessages.EmptyRewardCycle];
       if (selectedRewardCycle <= currentRewardCycle)
@@ -157,7 +157,7 @@ export const testPeriod = (
     string,
     (selectedRewardCycle: number) => [boolean, string]
   > = {
-    [TopicMapping[0]]: (selectedPeriod: number): [boolean, string] => {
+    [TopicList[0]]: (selectedPeriod: number): [boolean, string] => {
       if (selectedPeriod === undefined)
         return [false, SigFormErrorMessages.EmptyPeriod];
       if (selectedPeriod < 1)
@@ -166,7 +166,7 @@ export const testPeriod = (
         return [false, SigFormErrorMessages.PeriodExceedsMaximum];
       return [true, 'OK'];
     },
-    [TopicMapping[1]]: (selectedPeriod: number): [boolean, string] => {
+    [TopicList[1]]: (selectedPeriod: number): [boolean, string] => {
       if (selectedPeriod === undefined)
         return [false, SigFormErrorMessages.EmptyPeriod];
       if (selectedPeriod < 1)
@@ -175,7 +175,7 @@ export const testPeriod = (
         return [false, SigFormErrorMessages.PeriodExceedsMaximum];
       return [true, 'OK'];
     },
-    [TopicMapping[2]]: (): [boolean, string] => {
+    [TopicList[2]]: (): [boolean, string] => {
       // TODO: Should be equal to current lock period!
       if (selectedPeriod === undefined)
         return [false, SigFormErrorMessages.EmptyPeriod];
@@ -185,14 +185,14 @@ export const testPeriod = (
         return [false, SigFormErrorMessages.PeriodExceedsMaximum];
       return [true, 'OK'];
     },
-    [TopicMapping[3]]: (selectedPeriod: number): [boolean, string] => {
+    [TopicList[3]]: (selectedPeriod: number): [boolean, string] => {
       if (selectedPeriod === undefined)
         return [false, SigFormErrorMessages.EmptyPeriod];
       if (selectedPeriod !== 1)
         return [false, SigFormErrorMessages.AggCommitWrongPeriod(topic)];
       return [true, 'OK'];
     },
-    [TopicMapping[4]]: (selectedPeriod: number): [boolean, string] => {
+    [TopicList[4]]: (selectedPeriod: number): [boolean, string] => {
       if (selectedPeriod === undefined)
         return [false, SigFormErrorMessages.EmptyPeriod];
       if (selectedPeriod !== 1)

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -57,7 +57,6 @@ export const SigFormErrorMessages = {
     `The period for ${topic} signature should be 1.`,
   InvalidPoxAddress: (poxAddress: string) =>
     `Invalid PoX Address: ${poxAddress}.`,
-  InvalidTopic: (topic: string) => `Invalid Topic: ${topic}.`,
   MaxAmountTooBig: (maxAmount: number) =>
     `Max amount too big (${maxAmount} > ${Number.MAX_SAFE_INTEGER}).`,
   RewCycleGreaterThanCurrent: (currentRewardCycle: number) =>


### PR DESCRIPTION
The property tests added are the following:

- generate a valid signature for mainnet and testnet.
- create  a valid signature for stack-stx, stack-extend, stack-increase, stack-aggregation-commit and stack-aggregation-increase for mainnet and testnet.
- create a signature for mainnet and testnet with a larger period then permitted for stack-stx, stack-extend and stack-increase.
- create a signature for mainnet and testnet with a negative or zero period for stack-stx, stack-extend and stack-increase.
- create a signature for mainnet and tesnet with a past reward cycle for stack-stx, stack-extend and stack-increase.
- create a signature for mainnet and testnet with a reward cycle greater than current for stack-stx, stack-extend and stack-increase.
- create a signature for mainnet and testnet with an undefined reward cycle for stack-stx, stack-extend and stack-increase.
- create a signature for mainnet and testnet with a wrong period for stack-aggregation-commit and stack-aggregation-increase.
- create a signature for mainnet and testnet with a reward cycle that is not in the future for stack-aggregation-commit and stack-aggregation-increase.
- create a signature for mainnet and testnet with an undefined reward cycle for stack-aggregation-commit and stack-aggregation-increase.
- create a signature for mainnet and testnet with a non-existing topic.
- create a signature for mainnet and testnet with a btcAddress that is invalid.